### PR TITLE
blocklistctl: Fix missing option/character not found

### DIFF
--- a/bin/blocklistctl.c
+++ b/bin/blocklistctl.c
@@ -121,6 +121,9 @@ main(int argc, char *argv[])
 		case 'w':
 			wide = 1;
 			break;
+		case '?':
+			usage(0);
+			break;
 		default:
 			usage(o);
 			break;


### PR DESCRIPTION
If getopt(3) encounters a character not found in optstring or if it detects a missing option argument, it returns `?` (question mark).

It avoids:

    $ blacklistd -X
    blacklistd: illegal option -- X
    blacklistd: Unknown option `?'
    Usage: blacklistd ...