### PR TITLE
conf.c: Remove stray comment

### DIFF
--- a/bin/conf.c
+++ b/bin/conf.c
@@ -1005,7 +1005,6 @@ confset_match(const struct confset *cs, struct conf *c,
 #ifdef AF_ROUTE
 static int
 conf_route_perm(int fd) {
-/* Disable for now, the access check in the routing socket uses curlwp */
 #if defined(RTM_IFANNOUNCE) && defined(RT_ROUNDUP)
 	/*
 	 * Send a routing message that is not supported to check for access


### PR DESCRIPTION
When reverting 4ca698e97e8d442dcd0eb24bd5b1b4207011f872, this comment was missed.

Fixes:  dfd697cf3433390d906bfd8d75910e6f902ee55d