### PR TITLE
Fixup syslog() call that should have used logging function pointer

### DIFF
--- a/bin/blocklistd.c
+++ b/bin/blocklistd.c
@@ -322,7 +322,7 @@ again:
 		if (dbi.id[0]) {
 			run_change("rem", &c, dbi.id, 0);
 			sockaddr_snprintf(buf, sizeof(buf), "%a", ss);
-			syslog(LOG_INFO, "released %s/%d:%d after %d seconds",
+			(*lfun)(LOG_INFO, "released %s/%d:%d after %d seconds",
 			    buf, c.c_lmask, c.c_port, c.c_duration);
 		}
 		state_del(state, &c);


### PR DESCRIPTION
Obtained from:	https://github.com/freebsd/freebsd-src/commit/ff9238039995488aa15f64afea718037774941f7
FreeBSD PR:	236614
Submitted by:	Helge Oldach <freebsd@oldach.net>