### PR TITLE
Update blacklist-helper to not emit messages from pf during operation

### DIFF
--- a/libexec/blocklistd-helper
+++ b/libexec/blocklistd-helper
@@ -151,8 +151,8 @@ add)
 		    echo "block in quick $proto from <port$6> to any $port" | \
 		    /sbin/pfctl -a "$2/$6" -f -
 		# insert $ip/$mask into per-protocol/port anchored table
-		/sbin/pfctl -a "$2/$6" -t "port$6" -T add "$addr/$mask" && \
-		    echo OK
+		/sbin/pfctl -qa "$2/$6" -t "port$6" -T add "$addr/$mask" && \
+		    /sbin/pfctl -q -k $addr && echo OK
 		;;
 
 	esac
@@ -184,7 +184,7 @@ rem)
 		;;
 
 	pf)
-		/sbin/pfctl -a "$2/$6" -t "port$6" -T delete "$addr/$mask" && \
+		/sbin/pfctl -qa "$2/$6" -t "port$6" -T delete "$addr/$mask" && \
 		    echo OK
 		;;
 
@@ -224,7 +224,13 @@ flush)
 		;;
 
 	pf)
-		/sbin/pfctl -a "$2/$6" -t "port$6" -T flush && echo OK
+		# dynamically determine which anchors exist
+		anchors=$(/sbin/pfctl -a $2 -s Anchors)
+		for anchor in $anchors; do
+			/sbin/pfctl -a $anchor -t "port${anchor##*/}" -T flush
+			/sbin/pfctl -a $anchor -F rules
+		done
+		echo OK
 		;;
 	esac
 	;;


### PR DESCRIPTION
Use `pfctl -k` when blocking a site to kill active tcp connections from the blocked address.

Fix `purge` operation for pf, which must dynamically determine which filters have been created, so the filters can be flushed by name.

Obtained from:	https://github.com/freebsd/freebsd-src/commit/549f31e4590e97c7b9ee771a24fd2c84198f0dd8