### PR TITLE
blocklistd-helper: Silence bogus warning

### DIFF
--- a/libexec/blocklistd-helper
+++ b/libexec/blocklistd-helper
@@ -233,7 +233,7 @@ flush)
 
 	pf)
 		# dynamically determine which anchors exist
-		for anchor in $(/sbin/pfctl -a "$2" -s Anchors); do
+		for anchor in $(/sbin/pfctl -a "$2" -s Anchors 2>/dev/null); do
 		       /sbin/pfctl -a "$anchor" -t "port${anchor##*/}" -T flush
 		       /sbin/pfctl -a "$anchor" -F rules
 		done


### PR DESCRIPTION
Silence a bogus warning when starting up:

NetBSD pf:

    No ALTQ support in kernel
    ALTQ related functions disabled

FreeBSD pf:

    Anchor 'blacklistd' not found.

The anchor is indeed found and working correctly.  This patch just discards stderr's output, like in other places.