### PR TITLE
blocklistd: add runtime -U option to mark "BL_BADUSER" attempts as scored.

### DIFF
--- a/bin/blocklistd.8
+++ b/bin/blocklistd.8
@@ -35,7 +35,7 @@
 .Nd block and release ports on demand to avoid DoS abuse
 .Sh SYNOPSIS
 .Nm
-.Op Fl dfrv
+.Op Fl dfrUv
 .Op Fl C Ar controlprog
 .Op Fl c Ar configfile
 .Op Fl D Ar dbfile
@@ -225,6 +225,8 @@ listens to.
 The interval in seconds
 .Nm
 polls the state file to update the rules.
+.It Fl U
+Block also those trying to use a non-existent username.
 .It Fl v
 Cause
 .Nm

--- a/bin/blocklistd.c
+++ b/bin/blocklistd.c
@@ -227,7 +227,7 @@ process(bl_t bl)
 			dbi.count = c.c_nfail - 1;
 		/*FALLTHROUGH*/
 	case BL_BADUSER:
-		if (!blbaduser)
+		if (!blbaduser && bi->bi_type == BL_BADUSER)
 			break;
 		/*FALLTHROUGH*/
 	case BL_ADD:


### PR DESCRIPTION
This will allow blacklistd to count the attempt even when the user's account doesn't exist or the 'KbdInteractiveAuthentication' is set to 'no'

Requested by: FreeBSD user
See also:
https://forums.freebsd.org/threads/blacklistd-and-sshd-not-acting-immediately-according-to-logs.82523/