### PR TITLE
implement BLOCKLIST_BAD_USER as a "one-count" failure

### DIFF
--- a/bin/blocklistd.c
+++ b/bin/blocklistd.c
@@ -216,16 +216,19 @@ process(bl_t bl)
 	switch (bi->bi_type) {
 	case BL_ABUSE:
 		/*
-		 * If the application has signaled abusive behavior,
-		 * set the number of fails to be one less than the
-		 * configured limit.  Fallthrough to the normal BL_ADD
-		 * processing, which will increment the failure count
-		 * to the threshhold, and block the abusive address.
+		 * If the application has signaled abusive behavior, set the
+		 * number of fails to be two less than the configured limit.
+		 * Fall through to the normal BL_ADD and BL_BADUSER processing,
+		 * which will increment the failure count to the threshhold, and
+		 * block the abusive address.
 		 */
 		if (c.c_nfail != -1)
-			dbi.count = c.c_nfail - 1;
+			dbi.count = c.c_nfail - 2;
 		/*FALLTHROUGH*/
 	case BL_ADD:
+		dbi.count++;		/* will become += 2 */
+		/*FALLTHROUGH*/
+	case BL_BADUSER:
 		dbi.count++;
 		dbi.last = ts.tv_sec;
 		if (c.c_nfail != -1 && dbi.count >= c.c_nfail) {
@@ -253,9 +256,6 @@ process(bl_t bl)
 			goto out;
 		dbi.count = 0;
 		dbi.last = 0;
-		break;
-	case BL_BADUSER:
-		/* ignore for now */
 		break;
 	default:
 		(*lfun)(LOG_ERR, "unknown message %d", bi->bi_type);

--- a/bin/conf.c
+++ b/bin/conf.c
@@ -409,6 +409,8 @@ conf_parseline(const char *f, size_t l, char *p, struct conf *c, bool local)
 {
 	int e;
 
+	c->c_lineno = l;
+
 	while (*p && isspace((unsigned char)*p))
 		p++;
 

--- a/bin/conf.h
+++ b/bin/conf.h
@@ -34,6 +34,7 @@
 #include <sys/socket.h>
 
 struct conf {
+	size_t			c_lineno;
 	struct sockaddr_storage	c_ss;
 	int			c_lmask;
 	int			c_port;

--- a/bin/run.c
+++ b/bin/run.c
@@ -131,7 +131,8 @@ run_change(const char *how, const struct conf *c, char *id, size_t len)
 		prname = "udp";
 		break;
 	default:
-		(*lfun)(LOG_ERR, "%s: bad protocol %d", __func__, c->c_proto);
+		(*lfun)(LOG_ERR, "%s: bad protocol %d (line %zu)", __func__,
+		     c->c_proto, c->c_lineno);
 		return -1;
 	}
 

--- a/lib/libblocklist.3
+++ b/lib/libblocklist.3
@@ -106,26 +106,20 @@ The
 .Ar action
 parameter can take these values:
 .Bl -tag -width ".Dv BLOCKLIST_ABUSIVE_BEHAVIOR"
-.It Dv BLOCKLIST_AUTH_FAIL
+.It Va BLOCKLIST_BAD_USER
+The sending daemon has determined the username presented for
+authentication is invalid.
+This is considered as one failure count.
+.It Va BLOCKLIST_AUTH_FAIL
 There was an unsuccessful authentication attempt.
-.It Dv BLOCKLIST_AUTH_OK
-A user successfully authenticated.
-.It Dv BLOCKLIST_ABUSIVE_BEHAVIOR
-The sending daemon has detected abusive behavior
-from the remote system.
-The remote address should
-be blocked as soon as possible.
-.It Dv BLOCKLIST_BAD_USER
-The sending daemon has determined the username
-presented for authentication is invalid.
-The
-.Xr blocklistd 8
-daemon compares the username to a configured list of forbidden
-usernames and
-blocks the address immediately if a forbidden username matches.
-(The
-.Dv BLOCKLIST_BAD_USER
-support is not currently available.)
+This is considered as two failure counts together.
+.It Va BLOCKLIST_ABUSIVE_BEHAVIOR
+The sending daemon has detected abusive behavior from the remote system.
+This is considered as a total immediate failure.
+The remote address will be blocked as soon as possible.
+.It Va BLOCKLIST_AUTH_OK
+A valid user successfully authenticated.
+Any entry for the remote address will be removed as soon as possible.
 .El
 .Pp
 The


### PR DESCRIPTION
BLOCKLIST_BAD_USER (BL_BADUSER internally) was actually unimplemented
and as such unusable, and despite being documented as such it still
gained some users and has lead to confusion.

This change proposes that it be implemented as a failure with a count of
one for "nfails".

To provide a meaningful distinction BLOCKLIST_AUTH_FAIL is also now
be implemented with a count of two for "nfails" -- which seems
appropriate as an "authentication failure" sounds, to my ear at least,
as something more important than a "bad user" failure.

This allows for "bad user" reports (which, say in the case of sshd,
could be caused by a legitimate user making a typo) to be recorded as
failures, but perhaps not to immediately cause them to be locked
out (depending on the current configuration of course).

I think "invalid" should probably have been used here instead of "bad",
but that would now be an API change, as opposed to a minor usage change
and improvement.

BTW, I think the hinted at concept of the blocklist daemon having a list
of disallowed users is not a viable way to go -- it violates the
possibility that several different client daemons might have differing
concepts and policies about whether attempts to use a given username is
really violating some rule.  Also we shouldn't conflate the concept of
"username" here with local Unix user names, as they may not be related
at all.