### PR TITLE
DEBUG: blocklistctl: Print the rule name

### DIFF
--- a/bin/blocklistctl.c
+++ b/bin/blocklistctl.c
@@ -135,7 +135,7 @@ main(int argc, char *argv[])
 	clock_gettime(CLOCK_REALTIME, &ts);
 	wide = wide ? 8 * 4 + 7 : 4 * 3 + 3;
 	if (!noheader)
-		printf("%*.*s/ma:port\tid\tnfail\t%s\n", wide, wide,
+		printf("rulename\t%*.*s/ma:port\tid\tnfail\t%s\n", wide, wide,
 		    "address", remain ? "remaining time" : "last access");
 	for (i = 1; state_iterate(db, &c, &dbi, i) != 0; i = 0) {
 		char buf[BUFSIZ];
@@ -149,6 +149,7 @@ main(int argc, char *argv[])
 					continue;
 			}
 		}
+		printf("%s\t", c.c_name);
 		sockaddr_snprintf(buf, sizeof(buf), "%a", (void *)&c.c_ss);
 		printf("%*.*s/%s:%s\t", wide, wide, buf,
 		    star(mbuf, sizeof(mbuf), c.c_lmask),


### PR DESCRIPTION
Add a column that prints the packet filter rule name to be used.

There is no interest in merging this patch, having the rulename added in the first column may break existing scripts that parse the output of blocklistctl.

> [!NOTE]
> It is intended to help with debugging when duplicate locations appear in the output of the dump subcommand, chiefly to be used as a reference point for FreeBSD users transitioning from the old nomenclature to the new one, in the event that the pf package filter is used, along with a `-r` flag in blocklistd, and the anchor name is not found upon service startup.
> A simple solution would be to remove the database file (/var/db/blocklistd.db), it will be recreated upon blocklistd start.
> Or add an anchor with the name in that column, if we really care about the contents of the database.