### PR TITLE
blocklistctl.8: Add man page entry for rulename

### DIFF
--- a/bin/blocklistctl.8
+++ b/bin/blocklistctl.8
@@ -27,7 +27,7 @@
 .\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 .\" POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd January 27, 2025
+.Dd October 25, 2025
 .Dt BLOCKLISTCTL 8
 .Os
 .Sh NAME
@@ -82,6 +82,10 @@ sub-command consists of a header (unless
 was given) and one line for each record in the database, where each line
 has the following columns:
 .Bl -tag -width indent
+.It Ql rulename
+The packet filter rule name associated with the database entry,
+usually
+.Dv blocklistd .
 .It Ql address/ma:port
 The remote address, mask, and local port number of the client connection
 associated with the database entry.


### PR DESCRIPTION
Pull Request zoulasc/blocklist#34 introduced an extra column to display the name of the rule associated with the database entry.

Briefly document the purpose of the extra column.