### PR TITLE
blocklistd: Restore only if db file exists

### DIFF
--- a/bin/blocklistd.c
+++ b/bin/blocklistd.c
@@ -541,14 +541,15 @@ main(int argc, char *argv[])
 	state = state_open(dbfile, flags, 0600);
 	if (state == NULL)
 		state = state_open(dbfile,  flags | O_CREAT, 0600);
+	else {
+		if (restore) {
+			if (!flush)
+				rules_flush();
+			rules_restore();
+		}
+	}
 	if (state == NULL)
 		return EXIT_FAILURE;
-
-	if (restore) {
-		if (!flush)
-			rules_flush();
-		rules_restore();
-	}
 
 	if (!debug) {
 		if (daemon(0, 0) == -1)


### PR DESCRIPTION
Only attempt to restore the blocking rules if the file exists. Otherwise, when the service starts for the _very first time_, it will fail like:

    state_open: can't open `/var/db/blocklistd.db' (Inappropriate file type or format)
    blocklistctl: Can't open `/var/db/blocklistd.db': Inappropriate file type or format

This error was reported on FreeBSD's bug reporting platform:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=258411

This is a naive fix, chiefly to illustrate the issue.
To reproduce it.  Make sure the `-r` (Re-read the firewall rules) flag is set on blocklistd:
```
/etc/rd.d/blocklistd stop
rm -f /var/db/blocklistd.db
/etc/rc.d/blocklistd start
```
Check the logs (e.g., `dmesg -a`)

cc/ @emaste