### PR TITLE
blocklistd.conf: Use RFC1918 IPv4 address in example

### DIFF
--- a/etc/blocklistd.conf
+++ b/etc/blocklistd.conf
@@ -9,7 +9,7 @@ domain		*	*	named		*	3	12h
 
 # adr/mask:port	type	proto	owner		name	nfail	duration
 [remote]
-#129.168.0.0/16	*	*	*		=	*	*
+#192.168.0.0/16	*	*	*		=	*	*
 #[2001:db8::]/32:ssh	*	*	*		=	*	*
 #6161		=	=	=		=/24	=	=
 #*		stream	tcp	*		=	=	=


### PR DESCRIPTION
I suspect an RFC1918 example was intended, but two digits were transposed.  Reported on mastodon.social at
https://mastodon.social/@asmodai/116316630762241486.